### PR TITLE
Use Carpentries Lab theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 #------------------------------------------------------------
 
 # Which carpentry is this ("swc", "dc", or "lc")?
-carpentry: "dc"
+carpentry: "lab"
 
 # Overall title for pages.
 title: "Python for Atmosphere and Ocean Scientists"
@@ -15,6 +15,9 @@ email: "irving.damien@gmail.com"
 
 # Life cycle badge
 life_cycle: "stable"
+
+# DOI URL for published lesson
+doi: "https://doi.org/10.21105/jose.00037"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).


### PR DESCRIPTION
This updates the site configuration to use the Carpentries Lab style. See the screenshot below for a preview of what the theme will look like after merging.

![Screenshot 2021-06-29 at 16 18 02](https://user-images.githubusercontent.com/9694524/123814328-e5dd3a00-d8f5-11eb-872c-ded9e2b3881d.png)
